### PR TITLE
Fixing Debian builds

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: merecat
 Section: web
 Priority: optional
 Maintainer: Joachim Nilsson <troglobit@gmail.com>
-Build-Depends: debhelper (>= 9), dh-systemd (>= 1.5), libconfuse-dev, libssl-dev
+Build-Depends: debhelper (>= 9), dh-systemd (>= 1.5), pkg-config, libconfuse-dev, libssl-dev
 Homepage: https://github.com/troglobit/merecat
 Standards-Version: 3.9.7
 

--- a/debian/rules
+++ b/debian/rules
@@ -6,4 +6,7 @@ export DEB_BUILD_MAINT_OPTIONS = hardening=+all
 	dh $@ --with=systemd
 
 override_dh_auto_configure:
-	dh_auto_configure -- --enable-public-html --enable-htaccess --enable-htpasswd
+	dh_auto_configure -- --enable-public-html --enable-htaccess --enable-htpasswd --enable-builtin-icons
+
+override_dh_auto_test:
+	$(MAKE) check


### PR DESCRIPTION
There is no ITP for merecat that I could find. I would be happy to file an ITP and work on this.

As I see it, we will need to fix:

- logging (I am currently using rsyslog's `programname` to filter out merecat logs)
- ssl with passphrase protected keys