### PR TITLE
Fix for large files over SSL

### DIFF
--- a/src/libhttpd.c
+++ b/src/libhttpd.c
@@ -5066,7 +5066,7 @@ ssize_t httpd_write(struct http_conn *hc, void *buf, size_t len)
 	return rc;
 }
 
-ssize_t httpd_writev(struct http_conn *hc, struct iovec *iov, size_t num)
+ssize_t httpd_writev(struct http_conn *hc, struct iovec *iov, int num)
 {
 	ssize_t rc;
 

--- a/src/libhttpd.h
+++ b/src/libhttpd.h
@@ -402,7 +402,7 @@ extern ssize_t httpd_read(struct http_conn *hc, void *buf, size_t len);
 
 /* Write the requested buffer completely, accounting for interruptions. */
 extern ssize_t httpd_write(struct http_conn *hc, void *buf, size_t len);
-extern ssize_t httpd_writev(struct http_conn *hc, struct iovec *iov, size_t num);
+extern ssize_t httpd_writev(struct http_conn *hc, struct iovec *iov, int num);
 
 /* Generate debugging statistics syslog message. */
 extern void httpd_logstats(long secs);

--- a/src/ssl.h
+++ b/src/ssl.h
@@ -55,7 +55,7 @@ void httpd_ssl_log_errors(void);
 /* Wrappers for read()/write() and writev() */
 ssize_t httpd_ssl_read   (struct http_conn *hc, void *buf, size_t len);
 ssize_t httpd_ssl_write  (struct http_conn *hc, void *buf, size_t len);
-ssize_t httpd_ssl_writev (struct http_conn *hc, struct iovec *iov, size_t num);
+ssize_t httpd_ssl_writev (struct http_conn *hc, struct iovec *iov, int num);
 
 #else
 #define httpd_ssl_init(cert, key, dhparm, proto, ciphers) NULL


### PR DESCRIPTION
Implement httpd_ssl_writev as series of SSL_write calls
Must pass EXACT same arguments on retry or else get
"bad write retry" (0x1409f07f)

Changes http_ssl_writev "num" argument to "int" as per SUSv2
https://pubs.opengroup.org/onlinepubs/007908799/xsh/write.html
(Linux and FreeBSD follow the standard).