### PR TITLE
Fix file upload of big files with ssl enabled

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -417,10 +417,11 @@ void httpd_ssl_log_errors(void)
 
 ssize_t httpd_ssl_read(struct http_conn *hc, void *buf, size_t len)
 {
-	if (status(hc, SSL_read(hc->ssl, buf, len)))
+	int rc = SSL_read(hc->ssl, buf, len);
+	if (status(hc, rc))
 		return -1;
 
-	return len;
+	return rc;
 }
 
 ssize_t httpd_ssl_write(struct http_conn *hc, void *buf, size_t len)


### PR DESCRIPTION
[SSL_Read](https://www.openssl.org/docs/man1.1.1/man3/SSL_read.html#RETURN-VALUES) can return less than the requested amount of bytes, but httpd_ssl_read always returned the requested amount of bytes. This caused merecat to corrupt files > 16Kb leaving binary zeroes in the middle and trimming end of them.