### PR TITLE
fixing "make dist; make check"

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,5 +1,5 @@
 EXTRA_DIST       = merecat.conf start.sh stop.sh
-EXTRA_DIST      += cgi.sh gzip.sh redirect.sh location.sh
+EXTRA_DIST      += cgi.sh gzip.sh redirect.sh location.sh php.sh
 CLEANFILES       = *~ *.trs *.log
 TEST_EXTENSIONS  = .sh
 


### PR DESCRIPTION
After creating a tarball from a fresh git checkout with "make distcheck",
unpacking that tarball and running "make check", the tests would fail with

 fatal: making test-suite.log: failed to create php.trs
 fatal: making test-suite.log: failed to create php.log
 make[4]: *** [Makefile:487: test-suite.log] Error 1

This is due to tests/php.sh not being included in the tarball. Fixing it
by adding php.sh to EXTRA_DIST in tests/Makefile.am.

Fixes: github issue #31