### PR TITLE
Removed comment markers in front of defaults

### DIFF
--- a/merecat.conf
+++ b/merecat.conf
@@ -7,50 +7,46 @@
 ## (default is binding to any interface)
 #hostname=www.example.org
 
-## Port to listen to, overrides command line argument
-## Defaults to 80, or 443 when enabling HTTPS
-#port = 80
-
 ## Unpriviliged user to run as, usually nobody or www-data
-#username = nobody
+username = nobody
 
 ## Global .htpasswd (true) or local per-directory (false)
-#global-passwd = false
+global-passwd = false
 
 ## Chrooting is a security measure which means isolating the webserver's
 ## access to files only available from a the given directory.  To access
 ## files outside the chroot the administrator can either copy or bind
 ## mount files and directories into the chroot.
-#chroot = false
+chroot = false
 
 ## Only useful if not chrooting
-#check-symlinks = false
+check-symlinks = false
 
 ## Alt. charset=iso-8859-1
-#charset = UTF-8
+charset = UTF-8
 
 ## Deflate (gzip) compression level: -1 .. 9
 ## -1: Default (zlib's reasonable default, currently 6)
 ##  0: Disabled
 ##  1: Best speed
 ##  9: Best compression
-#compression-level = -1
+compression-level = -1
 
 ## Webserver document root, or chroot
-#directory = /var/www
+directory = /var/www
 
 ## When chrooting, alt. document root inside chroot
 ## => /var/www/htdocs
 #data-directory = /htdocs
 
 ## Skip dotfiles in dirlistings
-#list-dotfiles = false
+list-dotfiles = false
 
 ## Virtual hosting
 ## /var/www/cgi-bin/          <-- Shared CGI
 ## /var/www/git.example.com   <-- git.example.com
 ## /var/www/ftp.example.com   <-- ftp.example.com
-#virtual-host = false
+virtual-host = false
 
 ## Control the caching, in seconds, by setting the following header for
 ## all transactions.  Depends heavily on the content you provide, and
@@ -62,7 +58,7 @@
 ## Min max-age value 0 (browser caching disabled)
 ## Max max-age value 31536000 (1 year)
 ##
-#max-age = 0
+max-age = 0
 
 ## Some bots behave really badly and may overload your server.  Often
 ## they cannot be blocked based on IP address, so the only means we are
@@ -93,46 +89,46 @@
 ## Example: "**.sh|**.cgi"
 ##
 ## `limit` sets the max number of simultaneous CGI programs allowed.
+##  default is 50
 ##
-## The below values are the default, so to enable CGI only `enabled`
-## need to be set to 'true'.
-#cgi "**.cgi|/cgi-bin/*" {
-#    enabled = false
-#    limit   = 50
-#}
+## to enable CGI only `enabled` need to be set to 'true'.
+cgi "**.cgi|/cgi-bin/*" {
+    enabled = false
+    limit   = 50
+}
 
 ## The PHP module is bolted on top of the CGI module, so the same limits
 ## apply also to PHP scripts.  The below are the built-in defaults.
 ## Verify the path to the php-cgi binary for your system and expand on
 ## the pattern if you have, e.g. .php5 files.
-#php "**.php*" {
-#    enabled  = false
-#    cgi-path = "/usr/bin/php-cgi"
-#}
+php "**.php*" {
+    enabled  = false
+    cgi-path = "/usr/bin/php-cgi"
+}
 
 ## The SSI module, like PHP above, is built on top of the CGI module,
 ## and it also requires the Merecat SSI CGI script to be installed, the
 ## defaults are commented out below.  The silent setting controls the
 ## default <!--#config errmsg="..." --> value.
-#ssi "**.shtml" {
-#    enabled  = false
-#    silent   = false
-#    cgi-path = "cgi-bin/ssi"
-#}
+ssi "**.shtml" {
+    enabled  = false
+    silent   = false
+    cgi-path = "cgi-bin/ssi"
+}
 
 ## Server specific settings, overrides certain global settings
 ## Notice the HTTP redirect from the default server to HTTPS.
-#server default {
-#    port = 80
-#    redirect "/" {
-#        code = 301
-#        location = "https://$host$request_uri$args"
-#    }
-#}
-#server secure {
-#    port = 443
-#    ssl = on
-#    certfile = /etc/letsencrypt/live/example.com/fullchain.pem
-#    keyfile = /etc/letsencrypt/live/example.com/privkey.pem
-#    dhfile = certs/dhparam.pem
-#}
+server default {
+    port = 80
+    redirect "/" {
+        code = 301
+        location = "https://$host$request_uri$args"
+    }
+}
+server secure {
+    port = 443
+    ssl = on
+    certfile = /etc/letsencrypt/live/example.com/fullchain.pem
+    keyfile = /etc/letsencrypt/live/example.com/privkey.pem
+    dhfile = certs/dhparam.pem
+}


### PR DESCRIPTION
The defaults are still the defaults for the most of us.
Those who want non-defaults change what they want to change,
without the need of removing comment markers, #.