### PR TITLE
cgi-bin/printenv default no print env

### DIFF
--- a/www/cgi-bin/printenv
+++ b/www/cgi-bin/printenv
@@ -16,6 +16,14 @@ echo
 echo 'Id:'
 id
 echo
+
+exit 0
+# That exit is to prevent that scanners
+#   report a **possible** vulnerablity
+# Comment out that exit to show
+# what is in the environment
+# and content of "post", if any.
+
 echo 'Env:'
 printenv
 echo


### PR DESCRIPTION
The cgi-bin/printenv still does something, but vulnerability scanners
like https://github.com/sullo/nikto wouldn't report
+ /cgi-bin/printenv: Site appears vulnerable to the 'shellshock' vulnerability. See: http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-6271

The idea is not touching HTTP_USER_AGENT.