### PR TITLE
Fix `-t` option not being accepted by arg parser

### DIFF
--- a/src/merecat.c
+++ b/src/merecat.c
@@ -1361,7 +1361,7 @@ int main(int argc, char **argv)
 	int c;
 
 	ident = prognm = progname(argv[0]);
-	while ((c = getopt(argc, argv, "c:d:f:ghI:l:np:P:rsSu:vV")) != EOF) {
+	while ((c = getopt(argc, argv, "c:d:f:ghI:l:np:P:rsSt:u:vV")) != EOF) {
 		switch (c) {
 #ifndef HAVE_LIBCONFUSE
 		case 'c':


### PR DESCRIPTION
Commit a313356debe40640545cc528c47b042725bd0d36 migrated to a new arg parsing code based on `getopt`, but the used `getopt` string misses the required characters to let it accept the `-t` option that was accepted before the refactor, and is still documented as available.

Let's fix that by adding the aforementioned missing characters.