### PR TITLE
Remove redundant validity check in src/libhttp.c

### DIFF
--- a/src/libhttpd.c
+++ b/src/libhttpd.c
@@ -2659,7 +2659,7 @@ int httpd_parse_request(struct http_conn *hc)
 		}
 		*url = '\0';
 
-		if (strchr(reqhost, '/') || reqhost[0] == '.') {
+		if (reqhost[0] == '.') {
 			httpd_send_err(hc, 400, httpd_err400title, "", httpd_err400form, "4");
 			return -1;
 		}


### PR DESCRIPTION
The check `strchr(reqhost, '/')` seems to be unnecessary because the slash character is already detected by `url = strchr(reqhost, '/')` and replaced with '\0' using `*url = '\0'`. This ensures that `reqhost` never contains a slash after this point.

Here's the original code FYI:
```c
    2654                 reqhost = url + strlen(url_proto);
    2655                 url = strchr(reqhost, '/');
    2656                 if (!url) {
    2657                         httpd_send_err(hc, 400, httpd_err400title, "", httpd_err400form, "3");
    2658                         return -1;
    2659                 }
    2660                 *url = '\0';
    2661
    2662                 if (strchr(reqhost, '/') || reqhost[0] == '.') {
    2663                         httpd_send_err(hc, 400, httpd_err400title, "", httpd_err400form, "4");
    2664                         return -1;
    2665                 }
```